### PR TITLE
Use namespaced PyPI name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "battleship-mp"
+name = "kcsd-battleship-mp"
 version = "1.0.0"
 authors = [
   { name="Max Fischer", email="max.fischer@kit.edu" },


### PR DESCRIPTION
This PR changes the package name to add the `kcsd` prefix. This is used to avoid clashing with other projects on PyPI.