### PR TITLE
Fix internal error handling

### DIFF
--- a/battleship_mp/client.py
+++ b/battleship_mp/client.py
@@ -133,22 +133,18 @@ class GameSession:
         self._check_transition(State.PLACED, State.STARTED)
         l_sizes, l_coords, l_vertical = zip(*ships)
         try:
-            ships = tuple(
-                zip(
-                    *communicate(
-                        self._ws,
-                        "sizes",
-                        "coords",
-                        "vertical",
-                        sizes=l_sizes,
-                        coords=l_coords,
-                        vertical=l_vertical,
-                    )
-                )
+            zipped_ships = communicate(
+                self._ws,
+                "sizes",
+                "coords",
+                "vertical",
+                sizes=l_sizes,
+                coords=l_coords,
+                vertical=l_vertical,
             )
         except websockets.exceptions.ConnectionClosed:
             raise ConnectionClosed() from None
-        return ships
+        return tuple(zip(*zipped_ships))
 
     def announce_shot(self, coord: "tuple[int, int]") -> None:
         """Announce that a shot has been fired"""

--- a/battleship_mp/exceptions.py
+++ b/battleship_mp/exceptions.py
@@ -2,6 +2,10 @@ class ProtocolError(Exception):
     """Exchanged messages did not match the expected protocol"""
 
 
+class ConnectionClosed(Exception):
+    """The client/server connection was closed unexpectedly"""
+
+
 class GameError(Exception):
     """The shared game entered an erroneous state"""
 

--- a/battleship_mp/messages.py
+++ b/battleship_mp/messages.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, NoReturn
+from typing import Any, Iterable, NoReturn, Type
 import json
 
 from websockets.sync.connection import Connection
@@ -10,7 +10,7 @@ from .exceptions import ProtocolError, GameEnd
 ERRORS = {
     e.__name__: e for e in (ValueError, TypeError, KeyError, ProtocolError, GameEnd)
 }
-SERIALIZABLE_EXCEPTIONS = tuple(ERRORS)
+SERIALIZABLE_EXCEPTIONS: "tuple[Type[Exception], ...]" = tuple(ERRORS.values())
 
 
 def pack(

--- a/battleship_mp/messages.py
+++ b/battleship_mp/messages.py
@@ -10,6 +10,7 @@ from .exceptions import ProtocolError, GameEnd
 ERRORS = {
     e.__name__: e for e in (ValueError, TypeError, KeyError, ProtocolError, GameEnd)
 }
+SERIALIZABLE_EXCEPTIONS = tuple(ERRORS)
 
 
 def pack(

--- a/battleship_mp/server.py
+++ b/battleship_mp/server.py
@@ -43,7 +43,7 @@ class Game:
             await self.handle_shots()
         except GameEnd as ge:
             logger.info("end %s, winner %s", self.identifier, ge.winner)
-        except websockets.ConnectionClosed:
+        except websockets.exceptions.ConnectionClosed:
             # the connection of at least one player is gone
             # let those know that we can still reach
             for client in self.clients:

--- a/battleship_mp/server.py
+++ b/battleship_mp/server.py
@@ -43,6 +43,15 @@ class Game:
             await self.handle_shots()
         except GameEnd as ge:
             logger.info("end %s, winner %s", self.identifier, ge.winner)
+        except websockets.ConnectionClosed:
+            # the connection of at least one player is gone
+            # let those know that we can still reach
+            for client in self.clients:
+                if not client.websocket.open:
+                    logger.info("end %s, closed %s", self.identifier, client.identifier)
+                    continue
+                else:
+                    await client.websocket.send(pack(error=GameEnd(winner=None)))
         except Exception as exc:
             message = pack(error=exc)
             await gather(


### PR DESCRIPTION
This PR fixes error handling that would try to dump unserialisable data to peers. Major changes include:

- [x] Server explicitly handles websocket connections closing
- [x] Client explicitly handles websocket connections closing
- [x] Server explicitly handles known versus generic exceptions

Closes #12 