### PR TITLE
Prepare release v1.1.0

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,27 @@
+# from https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright 2023, Copyright Owner: Karlsruhe Institute of Technology (KIT).
-Authors: Collaborative Software Design Dozenten, Contact: csd-dozenten@lists.kit.edu
+Copyright 2023, Copyright Owner: Karlsruhe Institute of Technology (KIT). Authors: Collaborative Software Design Dozenten, Contact: csd-dozenten@lists.kit.edu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,14 @@
     :target: https://battleship-mp.readthedocs.io/en/latest
     :alt: Documentation Status
 
+.. image:: https://img.shields.io/pypi/v/kcsd-battleship-mp.svg
+    :alt: Available on PyPI
+    :target: https://pypi.python.org/pypi/kcsd-battleship-mp/
+
+.. image:: https://img.shields.io/github/license/kit-colsoftdes/battleship_mp.svg
+    :alt: License
+    :target: https://github.com/kit-colsoftdes/battleship_mp/blob/main/LICENSE
+
 This package provides a simple client and server for the Battleship game.
 It tries to be roughly compatible with the Collaborative Software Design implementation.
 Behind the scenes, it uses `WebSocket`_ for communication between client and server.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ KIT CSD Battleship MP documentation
    client
    player
    server
+   maintenance
 
 .. image:: https://readthedocs.org/projects/battleship-mp/badge/?version=latest
     :target: https://battleship-mp.readthedocs.io/en/latest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,18 @@ KIT CSD Battleship MP documentation
    player
    server
 
+.. image:: https://readthedocs.org/projects/battleship-mp/badge/?version=latest
+    :target: https://battleship-mp.readthedocs.io/en/latest
+    :alt: Documentation Status
+
+.. image:: https://img.shields.io/pypi/v/kcsd-battleship-mp.svg
+    :alt: Available on PyPI
+    :target: https://pypi.python.org/pypi/kcsd-battleship-mp/
+
+.. image:: https://img.shields.io/github/license/kit-colsoftdes/battleship_mp.svg
+    :alt: License
+    :target: https://github.com/kit-colsoftdes/battleship_mp/blob/main/LICENSE
+
 The :py:mod:`battleship_mp` provides a client/server
 for use as part of the KIT course Collaborative Software Design.
 

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -1,0 +1,25 @@
+Maintenance
+===========
+
+.. note::
+
+    This page is only relevant for maintainers of :py:mod:`battleship_mp`.
+
+Releases
+--------
+
+The package follows `Semantic Versioning`_
+and is automatically published to PyPI using GitHub actions.
+To trigger a release:
+
+1. Commit a new version
+    - Adjust and commit the ``version`` in ``pyproject.toml``
+    - Create a git tag for on commit (e.g. via ``git tag -a "v1.1.2" -m "description"``)
+    - Push the commit and tags to GitHub
+
+2. Publish the new release
+    - Create a new `GitHub release`_ from the recent version tag
+    - Wait for the action to push the release to PyPI
+
+.. _Semantic Versioning: https://semver.org
+.. _GitHub release: https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kcsd-battleship-mp"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
   { name="Max Fischer", email="max.fischer@kit.edu" },
 ]


### PR DESCRIPTION
This PR prepares the next release v1.1.0.

* [x] bump version to v1.1.0
* [x] add [GH release action](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries)
    * [x] added PyPI publish token to secrets
* [x] Update docs and metadata for publishing
    * [x] Adjust LICENSE to match GH autodetection (see https://github.com/licensee/licensee/issues/470)
    * [x] Add README and Docs badges
    * [x] Add maintenance/release documentation

-----

[Docs build on RTD](https://battleship-mp.readthedocs.io/en/release-v1.1.0/maintenance.html)